### PR TITLE
decision2: add an activities KB query

### DIFF
--- a/vle.extension.decision2/src/vle/extension/decision/Activities.cpp
+++ b/vle.extension.decision2/src/vle/extension/decision/Activities.cpp
@@ -151,6 +151,34 @@ devs::Time Activities::nextDate(const devs::Time& time)
     return result;
 }
 
+Activities::const_result_t
+Activities::beforeTimeHorizonAct(
+    const devs::Time& lowerBound,
+    const devs::Time& upperBound) const
+{
+    Activities::const_result_t beforeHorizonAct;
+
+    for (const_iterator activity = begin(); activity != end(); ++activity) {
+        switch (activity->second.state()) {
+        case Activity::WAIT:
+            if (activity->second.isValidHorizonTimeConstraint(lowerBound,
+                                                              upperBound))
+            {
+                beforeHorizonAct.push_back(activity);
+            }
+            break;
+        case Activity::STARTED:
+        case Activity::FF:
+        case Activity::DONE:
+        case Activity::FAILED:
+            break;
+        default:
+            throw utils::InternalError(_("Decision: unknown state"));
+        }
+    }
+    return beforeHorizonAct;
+}
+
 void Activities::removeWaitedAct(Activities::iterator it)
 {
     removeAct(m_waitedAct, it);

--- a/vle.extension.decision2/src/vle/extension/decision/Activities.hpp
+++ b/vle.extension.decision2/src/vle/extension/decision/Activities.hpp
@@ -223,6 +223,10 @@ public:
     const Activities::result_t& latestEndedAct() const
     { return m_latestEndedAct; }
 
+    Activities::const_result_t beforeTimeHorizonAct(
+        const devs::Time& lowerBound,
+        const devs::Time& upperBound) const;
+
     void removeWaitedAct(Activities::iterator it);
     void removeStartedAct(Activities::iterator it);
     void removeFailedAct(Activities::iterator it);

--- a/vle.extension.decision2/src/vle/extension/decision/Activity.cpp
+++ b/vle.extension.decision2/src/vle/extension/decision/Activity.cpp
@@ -215,4 +215,27 @@ bool Activity::isAfterTimeConstraint(const devs::Time& time) const
             _("Decision: activity time type invalid: %1%")) % (int)m_date);
 }
 
+bool Activity::isValidHorizonTimeConstraint(const devs::Time& lowerBound,
+                                            const devs::Time& upperBound) const
+{
+    switch (m_date & (START | FINISH | MINS | MAXS | MINF | MAXF)) {
+    case START | FINISH:
+        return m_start <= upperBound and lowerBound <= m_finish;
+
+    case START | MINF | MAXF:
+        return m_start <= upperBound  and lowerBound <= m_maxfinish;
+
+    case MINS | MAXS | FINISH:
+        return m_minstart <= upperBound and lowerBound <= m_maxfinish;
+
+    case MINS | MAXS | MINF | MAXF:
+        return m_minstart <= upperBound and lowerBound <= m_maxfinish;
+
+    default:
+        break;
+    }
+    throw utils::InternalError(fmt(
+            _("Decision: activity time type invalid: %1%")) % (int)m_date);
+}
+
 }}} // namespace vle model decision

--- a/vle.extension.decision2/src/vle/extension/decision/Activity.hpp
+++ b/vle.extension.decision2/src/vle/extension/decision/Activity.hpp
@@ -193,6 +193,8 @@ public:
     bool isValidTimeConstraint(const devs::Time& time) const;
     bool isBeforeTimeConstraint(const devs::Time& time) const;
     bool isAfterTimeConstraint(const devs::Time& time) const;
+    bool isValidHorizonTimeConstraint(const devs::Time& lowerBound,
+                                      const devs::Time& upperBound) const;
 
     const State& state() const { return m_state; }
     bool isInWaitState() const { return m_state == WAIT; }


### PR DESCRIPTION
The activities inside the result of the query are the one than can be
started before a time horizon.
